### PR TITLE
fix: web创建sql数据库测试连接中 postgresql 数据库连接抛错

### DIFF
--- a/server/client/sql_client.go
+++ b/server/client/sql_client.go
@@ -83,8 +83,8 @@ func newMysqlClient(sqlInfo model.SqlDatabaseInfo) (db *sql.DB, err error) {
 		dsn = fmt.Sprintf("%s:%s@%s:%d/%s?%s", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName, sqlInfo.Charset)
 	case "mysql":
 		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName, sqlInfo.Charset)
-	case "postgres":
-		dsn = fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=verify-full", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName)
+	case "postgresql":
+		dsn = fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName)
 	}
 
 	db, err = sql.Open(sqlInfo.Type, dsn)

--- a/server/client/sql_client.go
+++ b/server/client/sql_client.go
@@ -84,6 +84,7 @@ func newMysqlClient(sqlInfo model.SqlDatabaseInfo) (db *sql.DB, err error) {
 	case "mysql":
 		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName, sqlInfo.Charset)
 	case "postgresql":
+		sqlInfo.Type = "postgres"
 		dsn = fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", sqlInfo.User, sqlInfo.Password, sqlInfo.Host, sqlInfo.Port, sqlInfo.DbName)
 	}
 


### PR DESCRIPTION
1. 修改Type值从 postgres => postgresql
![postbug](https://github.com/Runner-Go-Team/RunnerGo-engine-open/assets/34022817/d15fab46-77a1-451a-8361-47e6c1a6ca15)

2. 关闭连接默认启用的ssl
